### PR TITLE
Reorganize Ansible inventory hosts file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure '2' do |config|
 	# The only machine available at the moment is "test-ubuntu-precise"
 
 	def apply_test_vm_defaults(config)
-		config.vm.network :private_network, ip: "192.168.33.20"
+		config.vm.network :private_network, ip: "192.168.33.21"
 	end
 
 	def apply_test_ansible_defaults(ansible)

--- a/inventory
+++ b/inventory
@@ -1,9 +1,16 @@
-[vagrant]
+[boxed]
 192.168.33.20
+
+[test-ubuntu-precise]
+192.168.33.21
 
 [vagrant:vars]
 ansible_ssh_user=vagrant
 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
 
 [test:children]
-vagrant
+test-ubuntu-precise
+
+[vagrant:children]
+boxed
+test


### PR DESCRIPTION
Assigns individual IPs and host groups for boxed and test.

Fixes zenoamaro/ansible-postgresql#1
